### PR TITLE
ウィンドウサイズとターミナルサイズが一致するよう修正

### DIFF
--- a/src/tty/teletype_manager.rs
+++ b/src/tty/teletype_manager.rs
@@ -45,8 +45,8 @@ impl TeletypeManager {
             hold: true,
         };
         let window_size = WindowSize {
-            num_lines: 50,
-            num_cols: 80,
+            num_lines: 64,
+            num_cols: 64,
             cell_width: 8,
             cell_height: 8,
         };


### PR DESCRIPTION
最終的にはウィンドウを広げると描画領域を広げたい。
ひとまず 64x64 の範囲に描画する