### PR TITLE
btm が返す文字列を描画

### DIFF
--- a/res/rect.fs
+++ b/res/rect.fs
@@ -8,6 +8,8 @@ layout (binding = 2) uniform sampler u_GlyphSampler;
 
 void main()
 {
-    vec4 color = texture(sampler2D(u_GlyphTexture, u_GlyphSampler), v_Uv);
-    o_Color = vec4(color.xyz, 1.0);
+    // グリフをアルファで抜く
+    // TODO: 色に対応する
+    vec4 alpha = texture(sampler2D(u_GlyphTexture, u_GlyphSampler), v_Uv);
+    o_Color = vec4(vec3(1.0), alpha);
 }

--- a/res/rect.vs
+++ b/res/rect.vs
@@ -25,23 +25,24 @@ void main()
     gl_Position = vec4(position, 0.0, 1.0);
 
     // TODO: 条件分岐を消したい
+    // TODO: UV の上下反転をちゃんと考えたい
     // 0 - 3
     // |   |
     // 1 - 2
-    if (gl_VertexIndex == 0)
+    if (gl_VertexIndex == 1)
     {
         v_Uv = characterData.uv0;
     }
-    else if (gl_VertexIndex == 1)
+    else if (gl_VertexIndex == 0)
     {
         v_Uv.x = characterData.uv0.x;
         v_Uv.y = characterData.uv1.y;
     }
-    else if (gl_VertexIndex == 2)
+    else if (gl_VertexIndex == 3)
     {
         v_Uv = characterData.uv1;
     }
-    else if (gl_VertexIndex == 3)
+    else if (gl_VertexIndex == 2)
     {
         v_Uv.x = characterData.uv1.x;
         v_Uv.y = characterData.uv0.y;

--- a/src/gfx/glyph_manager.rs
+++ b/src/gfx/glyph_manager.rs
@@ -28,7 +28,8 @@ impl GlyphManager {
             )
             .unwrap();
 
-        for char_code in ('a'..='z').chain('A'..='Z') {
+        // ASCII コードで使いそうなグリフをあらかじめ抽出しておく
+        for char_code in (0 as char)..='~' {
             let rasterized_glyph = rasterizer
                 .get_glyph(crossfont::GlyphKey {
                     character: char_code,


### PR DESCRIPTION
いくつかのグリフはまだ描画されてないが追って対応する
更新イベントが繋がってないので画面サイズを変えると再描画される

<img width="850" alt="スクリーンショット 2023-10-22 23 22 14" src="https://github.com/dearshuto/shalacritty/assets/17079150/bc513973-ee8e-4097-af14-c0dc105bea14">
