### PR TITLE
rust バージョンを明記

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "shalacritty"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.73"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
1.73 よりいくつか前のバージョンでも動作すると思う。
現在利用していたバージョンを記載しておく。