### PR TITLE
背景画像が設定されない不具合を修正

### DIFF
--- a/src/gfx/detail/background_renderer.rs
+++ b/src/gfx/detail/background_renderer.rs
@@ -117,7 +117,8 @@ impl<'a> BackgroundRenderer<'a> {
         if self.texture_path_cache.is_some() {
             return;
         } else {
-            self.texture_path_cache = Some(Path::new(".").to_path_buf());
+            let path = image_path.as_ref().to_path_buf();
+            self.texture_path_cache = Some(path);
         }
 
         let mut instance = None;


### PR DESCRIPTION
⇩ でデグレした。そもそも背景画像の有効性判定が間違っていた
560e54a9f7071a823304917259ee1faa293cebce