### PR TITLE
テキストバッファーの更新範囲を最適化する仕込み

### DIFF
--- a/src/gfx/detail/mod.rs
+++ b/src/gfx/detail/mod.rs
@@ -8,4 +8,4 @@ pub use cursor_renderer::CursorRenderer;
 pub use font_engine::FontEngine;
 pub use glyph_writer::{CharacterData, GlyphImagePatch, GlyphWriter, IGlyphManager};
 pub use scan_buffer_renderer::ScanBufferRenderer;
-pub use text_renderer::TextRenderer;
+pub use text_renderer::{BufferPatch, CharacterData as CharacterInfoData, TextRenderer};

--- a/src/gfx/detail/text_renderer.rs
+++ b/src/gfx/detail/text_renderer.rs
@@ -6,14 +6,22 @@ use winit::window::WindowId;
 
 use crate::gfx::{content_plotter::Diff, GlyphTexturePatch};
 
+pub struct BufferPatch {
+    pub binary: Vec<u8>,
+    pub partial_sizes: [usize; 8],
+    pub src_offsets: [usize; 8],
+    pub dst_offsets: [usize; 8],
+    pub count: u8,
+}
+
 #[repr(C)]
 #[derive(Debug, Pod, Copy, Clone, Zeroable)]
-struct CharacterData {
-    transform0: [f32; 4],
-    transform1: [f32; 4],
-    fore_ground_color: [f32; 4],
-    uv_bl: [f32; 2],
-    uv_tr: [f32; 2],
+pub struct CharacterData {
+    pub transform0: [f32; 4],
+    pub transform1: [f32; 4],
+    pub fore_ground_color: [f32; 4],
+    pub uv_bl: [f32; 2],
+    pub uv_tr: [f32; 2],
 }
 
 pub struct TextRenderer<'a> {
@@ -241,6 +249,7 @@ impl<'a> TextRenderer<'a> {
         queue: &wgpu::Queue,
         id: WindowId,
         diff: &Diff,
+        buffer_patches: &[BufferPatch],
         glyph_texture_patches: &[GlyphTexturePatch],
     ) {
         let Some(buffer) = self.character_storage_block_table.get(&id) else {
@@ -253,28 +262,14 @@ impl<'a> TextRenderer<'a> {
         // 文字数
         self.character_count = diff.item_count() as u32;
 
-        let data = diff
-            .character_info_array()
-            .iter()
-            .map(|info| {
-                let t = info.transform;
-                (
-                    info.index,
-                    CharacterData {
-                        transform0: [t[0], t[1], t[2], 0.0],
-                        transform1: [t[3], t[4], t[5], 0.0],
-                        fore_ground_color: info.fore_ground_color,
-                        uv_bl: [info.uv0[0], info.uv0[1]],
-                        uv_tr: [info.uv1[0], info.uv1[1]],
-                    },
-                )
-            })
-            .collect::<Vec<(usize, CharacterData)>>();
-
-        for (index, data) in data {
-            let offset = index * std::mem::size_of::<CharacterData>();
-            let binary = bytemuck::bytes_of(&data);
-            queue.write_buffer(buffer, offset as u64, binary);
+        for buffer_patch in buffer_patches {
+            for index in 0..buffer_patch.count {
+                let src_offset = buffer_patch.src_offsets[index as usize];
+                let dst_offset = buffer_patch.dst_offsets[index as usize];
+                let size = buffer_patch.partial_sizes[index as usize];
+                let bibary = &buffer_patch.binary[src_offset..(src_offset + size)];
+                queue.write_buffer(buffer, dst_offset as u64, bibary);
+            }
         }
 
         for texture_patch in glyph_texture_patches {

--- a/src/gfx/renderer.rs
+++ b/src/gfx/renderer.rs
@@ -8,7 +8,7 @@ use winit::{
 
 use super::{
     content_plotter::{Diff, GlyphTexturePatch},
-    detail::{CursorRenderer, ScanBufferRenderer, TextRenderer},
+    detail::{BufferPatch, CharacterInfoData, CursorRenderer, ScanBufferRenderer, TextRenderer},
     IRenderPlugin, UpdateParams,
 };
 
@@ -250,10 +250,46 @@ where
             self.background_color = *background_color;
         }
 
+        let buffer_patches: Vec<_> = render_update_params
+            .diff()
+            .character_info_array()
+            .iter()
+            .map(|info| {
+                let t = info.transform;
+                let data = CharacterInfoData {
+                    transform0: [t[0], t[1], t[2], 0.0],
+                    transform1: [t[3], t[4], t[5], 0.0],
+                    fore_ground_color: info.fore_ground_color,
+                    uv_bl: [info.uv0[0], info.uv0[1]],
+                    uv_tr: [info.uv1[0], info.uv1[1]],
+                };
+
+                let binary = bytemuck::bytes_of(&data).to_vec();
+                let binary_size = binary.len();
+                BufferPatch {
+                    binary,
+                    partial_sizes: [binary_size, 0, 0, 0, 0, 0, 0, 0],
+                    src_offsets: [0; 8],
+                    dst_offsets: [
+                        info.index * std::mem::size_of::<CharacterInfoData>(),
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                    ],
+                    count: 1, // TODO
+                }
+            })
+            .collect();
+
         self.text_renderer.update(
             queue,
             id,
             render_update_params.diff(),
+            &buffer_patches,
             render_update_params.glyph_texture_patches(),
         );
 


### PR DESCRIPTION
差分を細かいバイナリーに変換してデータの変更範囲を減らす
書き込むバイト量が減る代わりに頻度は増えるので、
それがどうパフォーマンスに影響するかは気にしたい