### PR TITLE
タブ切り替えのショートカットハンドリングを改善

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -80,6 +80,11 @@ impl App {
                         } {
                             workspace.send_input(window_id, name_key, modifiers_state);
                         }
+
+                        // 装飾キーが押されてると text_with_all_modifiers() が取得できないときがあるのでその救済措置
+                        if let Some(text) = event.key_without_modifiers().to_text() {
+                            workspace.send_input(window_id, text, modifiers_state);
+                        }
                     }
                     WindowEvent::CloseRequested => {
                         target.exit();

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -265,12 +265,11 @@ impl<'a> Workspace<'a> {
             return Action::DumpDebugInfo;
         }
 
-        // Ctrl+<0~4>
-        for index in 0..5 {
-            if modifier_state.contains(ModifiersState::CONTROL)
-                && input == String::from_utf8(vec![49 + index]).unwrap()
-            {
-                return Action::ActivateTab(index as u32);
+        // Ctrl+<1~4>
+        for tab_number in 1..=4 {
+            if modifier_state.contains(ModifiersState::CONTROL) && input == tab_number.to_string() {
+                // インデックスとしては 0 始まりなので -1 しておく
+                return Action::ActivateTab(tab_number - 1);
             }
         }
 


### PR DESCRIPTION
Windows 環境だと装飾キーがあると取れない入力があった
統一的に Ctrl-<数字> さばくことを目指す