### PR TITLE
サブパス描画の仕組みを導入

### DIFF
--- a/term-gfx/src/backends/vk.rs
+++ b/term-gfx/src/backends/vk.rs
@@ -576,9 +576,14 @@ impl IBackend for BackendVk {
             attachment: 0,
             layout: ash::vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
         }];
-        let subpass_description = [ash::vk::SubpassDescription::default()
-            .color_attachments(&color_attachments)
-            .pipeline_bind_point(ash::vk::PipelineBindPoint::GRAPHICS)];
+        let subpass_description = [
+            ash::vk::SubpassDescription::default()
+                .color_attachments(&color_attachments)
+                .pipeline_bind_point(ash::vk::PipelineBindPoint::GRAPHICS),
+            ash::vk::SubpassDescription::default()
+                .color_attachments(&color_attachments)
+                .pipeline_bind_point(ash::vk::PipelineBindPoint::GRAPHICS),
+        ];
         let render_pass = unsafe {
             device.create_render_pass(
                 &ash::vk::RenderPassCreateInfo::default()
@@ -1175,6 +1180,8 @@ impl IBackend for BackendVk {
                 0, /*first_instance*/
             );
         }
+
+        unsafe { device.cmd_next_subpass(command_buffer, ash::vk::SubpassContents::INLINE) }
 
         // レンダーパス終わり
         unsafe { device.cmd_end_render_pass(command_buffer) }


### PR DESCRIPTION
フレームバッファーに直接描画するなら、
レンダーパスごと切り替えるより、サブパスにまとめた方がシンプルになりそう
複数のサブパスを決めうちで用意してそれを必要なだけ使うような実装にしてみた

ただ ShaderObject が使えるならそっちの方がよりシンプルかもしれない