### PR TITLE
グリフ配置のパラメーターに設定ファイルのデフォルト値を踏襲

### DIFF
--- a/shalacritty/src/detail/glyph_extract_service.rs
+++ b/shalacritty/src/detail/glyph_extract_service.rs
@@ -54,7 +54,7 @@ impl GlyphExtractService {
                 config_receiver,
                 receiver: string_receiver,
                 rasterizer: crossfont::Rasterizer::new().unwrap(),
-                glyph_writer: GlyphWriterEx::new(8, 8),
+                glyph_writer: GlyphWriterEx::new(32, 32),
                 font_key: None,
                 current_font_size: None,
                 table: Default::default(),


### PR DESCRIPTION
あえて別の値を渡す理由もないので修正
将来的には設定ファイルを監視して動的に計算する