### PR TITLE
グリフ形状の取得に失敗した場合のエラーチェックを追加

### DIFF
--- a/shaka/src/services/rendering_service/glyph_table.rs
+++ b/shaka/src/services/rendering_service/glyph_table.rs
@@ -28,7 +28,15 @@ impl GlyphTable {
 
     // offsetx, offsety, width, height
     pub fn get_rect(&self, code: char) -> Option<[u32; 4]> {
-        self.table.get(&code).copied()
+        let Some(rect) = self.table.get(&code) else {
+            return None;
+        };
+
+        if !(rect[2] > 0 && rect[3] > 0) {
+            return None;
+        }
+
+        Some(*rect)
     }
 
     pub fn get_range(&self, code: char) -> Option<[f32; 4]> {

--- a/shaka/src/services/rendering_service/mod.rs
+++ b/shaka/src/services/rendering_service/mod.rs
@@ -877,7 +877,9 @@ impl RenderingService {
                 );
 
                 // グリフデータの書き込み
-                let rect = self.glyph_table.get_rect(code).unwrap();
+                let Some(rect) = self.glyph_table.get_rect(code) else {
+                    continue;
+                };
                 let offset_x = rect[0];
                 let offset_y = rect[1];
                 let width = rect[2];


### PR DESCRIPTION
文字コードに対応する字形に見た目に関する形状がない場合に対応
将来の最適化で、GlyphTable の内部情報ごとなくてもいいかもしれない