### PR TITLE
グリフ抽出失敗でクラッシュする不具合を回避

### DIFF
--- a/shaka/src/services/rendering_service/mod.rs
+++ b/shaka/src/services/rendering_service/mod.rs
@@ -847,7 +847,9 @@ impl RenderingService {
                     .await
                     .unwrap();
 
-                let mut glyph = receiver.await.unwrap();
+                let Ok(mut glyph) = receiver.await else {
+                    continue;
+                };
 
                 // 管理用データを構築
                 let Some(offset) = self


### PR DESCRIPTION
いったん処理をすかす
クラッシュよりはまし