### PR TITLE
グリフの描画位置のオフセットをサポート

### DIFF
--- a/shaka/src/services/glyph_extract_service/mod.rs
+++ b/shaka/src/services/glyph_extract_service/mod.rs
@@ -28,6 +28,9 @@ pub struct Glyph {
     pub width: i32,
     pub height: i32,
 
+    pub origin_x: i32,
+    pub origin_y: i32,
+
     // RGBA
     pub data: Vec<u8>,
 }
@@ -108,6 +111,8 @@ impl GlyphExtractService {
             width: rect.width(),
             height: rect.height(),
             data: canvas.pixels,
+            origin_x: 0,
+            origin_y: 0,
         };
         request.response.send(glyph).unwrap();
     }

--- a/shaka/src/services/rendering_service/glyph_table.rs
+++ b/shaka/src/services/rendering_service/glyph_table.rs
@@ -5,6 +5,8 @@ pub struct Rect {
     pub offsety: u32,
     pub width: u32,
     pub height: u32,
+    pub offset_x: i32,
+    pub offset_y: i32,
 }
 
 pub struct GlyphTable {
@@ -28,6 +30,8 @@ impl GlyphTable {
         offsety: u32,
         width: u32,
         height: u32,
+        offset_x: i32,
+        offset_y: i32,
     ) {
         self.table.insert(
             char,
@@ -36,6 +40,8 @@ impl GlyphTable {
                 offsety,
                 width,
                 height,
+                offset_x,
+                offset_y,
             },
         );
     }

--- a/shaka/src/services/rendering_service/mod.rs
+++ b/shaka/src/services/rendering_service/mod.rs
@@ -925,6 +925,8 @@ impl RenderingService {
                     offset[1],
                     glyph.width as u32,
                     glyph.height as u32,
+                    glyph.origin_x,
+                    glyph.origin_y,
                 );
 
                 // グリフデータの書き込み


### PR DESCRIPTION
まずはデータを用意
オフセットはゼロに設定してるので今のところ挙動に変化はない